### PR TITLE
Refactor action startup and ownership

### DIFF
--- a/Graphics_demo/src/engine/xGraphicView.cpp
+++ b/Graphics_demo/src/engine/xGraphicView.cpp
@@ -2,6 +2,8 @@
 #include <QMouseEvent>
 #include <QImage>
 #include <QDebug>
+#include <memory>
+#include <utility>
 #include "action/xActionPreviewInterface.h"
 #include "action/xActionDefault.h"
 #include "entity/xEntity.h"
@@ -23,24 +25,14 @@ xGraphicView::xGraphicView(QGraphicsScene *scene, QWidget *parent)
 	m_pixmap->setFlag(QGraphicsItem::ItemIsSelectable, false);
 	scene->addItem(m_pixmap);
 
-	m_default = new xActionDefault(this);
+	m_default = std::make_unique<xActionDefault>(this);
 }
 
-xGraphicView::~xGraphicView()
-{
-	if (m_action)
-		delete m_action;
-	if (m_default)
-		delete m_default;
-}
+xGraphicView::~xGraphicView() = default;
 
-void xGraphicView::setAction(xActionPreviewInterface *action) noexcept
+void xGraphicView::setAction(std::unique_ptr<xActionPreviewInterface> action) noexcept
 {
-	if (m_action)
-	{
-		delete m_action;
-	}
-	m_action = action;
+	m_action = std::move(action);
 }
 
 void xGraphicView::finishAction()
@@ -51,8 +43,7 @@ void xGraphicView::finishAction()
 			m_action->confirm();
 		else
 			m_action->cancel();
-		delete m_action;
-		m_action = nullptr;
+		m_action.reset();
 	}
 }
 
@@ -61,8 +52,7 @@ void xGraphicView::cancelAction()
 	if (m_action)
 	{
 		m_action->cancel();
-		delete m_action;
-		m_action = nullptr;
+		m_action.reset();
 	}
 }
 

--- a/Graphics_demo/src/engine/xGraphicView.h
+++ b/Graphics_demo/src/engine/xGraphicView.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QGraphicsView>
+#include <memory>
 
 class xActionInterface;
 class xActionPreviewInterface;
@@ -14,9 +15,9 @@ public:
 	xGraphicView(QGraphicsScene *scene, QWidget *parent);
 	~xGraphicView();
 
-	auto getAction() const noexcept { return m_action; }
+	auto getAction() const noexcept { return m_action.get(); }
 	// 设置新的Action，将会把上一个Action结束并释放
-	void setAction(xActionPreviewInterface *action) noexcept;
+	void setAction(std::unique_ptr<xActionPreviewInterface> action) noexcept;
 	// 返回视图缩放比例
 	qreal scaleFactor() const { return transform().m11(); }
 	// 调整缩放大小到自适应界面
@@ -47,8 +48,8 @@ private:
 	void onScaleChanged();
 
 private:
-	xActionPreviewInterface *m_action = nullptr;
-	xActionDefault *m_default = nullptr;
+	std::unique_ptr<xActionPreviewInterface> m_action;
+	std::unique_ptr<xActionDefault> m_default;
 	QGraphicsPixmapItem *m_pixmap = nullptr;
 	qreal m_initFactor = 0.0;
 };

--- a/Graphics_demo/src/ui/MainWindow.cpp
+++ b/Graphics_demo/src/ui/MainWindow.cpp
@@ -4,9 +4,12 @@
 #include <QGraphicsScene>
 #include <QPainter>
 #include <QStyleOption>
+#include <QString>
 #include <QThread>
 #include <QTimer>
 #include <functional>
+#include <memory>
+#include <utility>
 
 #include "FunctionsTabWidget.h"
 #include "OperationWidget.h"
@@ -78,65 +81,91 @@ MainWindow::~MainWindow()
     m_scene->deleteLater();
 }
 
-void MainWindow::startAction(const std::function<xActionPreviewInterface *()> &factory, bool enableCalc)
+void MainWindow::startAction(ActionDescriptor descriptor)
 {
-    auto opw = new OperationWidget(ui.r_pop_widget);
-    m_vLayout->addWidget(opw);
+    if (!descriptor.factory)
+        return;
+
+    destroyOperationWidget();
+
+    m_operationWidget = new OperationWidget(ui.r_pop_widget);
+    m_operationWidget->setActionName(QString::fromUtf8(descriptor.name));
+    m_operationWidget->setCalcEnabled(descriptor.enableCalc);
+    m_operationWidget->setNextEnabled(descriptor.enableNext);
+    m_vLayout->addWidget(m_operationWidget);
     ui.r_main_widget->hide();
     ui.r_pop_widget->show();
 
-    m_view->setAction(factory());
+    m_view->setAction(descriptor.factory());
 
-    connect(opw, &OperationWidget::confirmEmit, this, &MainWindow::onOperateFinished);
-    connect(opw, &OperationWidget::cancelEmit, this, &MainWindow::onOperateCanceled);
-    if (enableCalc)
+    auto operationWidget = m_operationWidget;
+    connect(operationWidget, &QObject::destroyed, this, [this, operationWidget] {
+        if (m_operationWidget == operationWidget)
+            m_operationWidget = nullptr;
+    });
+    connect(m_operationWidget, &OperationWidget::confirmEmit, this, &MainWindow::onOperateFinished);
+    connect(m_operationWidget, &OperationWidget::cancelEmit, this, &MainWindow::onOperateCanceled);
+    if (descriptor.enableCalc)
     {
-        connect(opw, &OperationWidget::calcEmit, this, [=] {
+        connect(m_operationWidget, &OperationWidget::calcEmit, this, [this] {
             if (auto action = m_view->getAction(); action != nullptr)
                 action->calculate();
         });
     }
-    connect(opw, &OperationWidget::nextEmit, this, [=] {
-        m_view->finishAction();
-        m_view->setAction(factory());
-    });
+    if (descriptor.enableNext)
+    {
+        connect(m_operationWidget, &OperationWidget::nextEmit, this, [this, descriptor = std::move(descriptor)] {
+            m_view->finishAction();
+            m_view->setAction(descriptor.factory());
+        });
+    }
+}
+
+void MainWindow::destroyOperationWidget()
+{
+    if (m_operationWidget == nullptr)
+        return;
+
+    m_vLayout->removeWidget(m_operationWidget);
+    m_operationWidget->deleteLater();
+    m_operationWidget = nullptr;
 }
 
 void MainWindow::onDrawLine()
 {
-    startAction([=] { return new xActionDrawLine(m_view); }, false);
+    startAction({ "直线", [this] { return std::make_unique<xActionDrawLine>(m_view); } });
 }
 void MainWindow::onDrawCircle()
 {
-    startAction([=] { return new xActionDrawCircle(m_view); }, false);
+    startAction({ "圆", [this] { return std::make_unique<xActionDrawCircle>(m_view); } });
 }
 void MainWindow::onDrawArc()
 {
-    startAction([=] { return new xActionDrawArc(m_view); }, false);
+    startAction({ "圆弧", [this] { return std::make_unique<xActionDrawArc>(m_view); } });
 }
 void MainWindow::onDrawRegLine()
 {
-    startAction([=] { return new xActionDrawRegLine(m_view); }, false);
+    startAction({ "线型区域", [this] { return std::make_unique<xActionDrawRegLine>(m_view); } });
 }
 void MainWindow::onDrawRegCircle()
 {
-    startAction([=] { return new xActionDrawRegCircle(m_view); }, false);
+    startAction({ "圆形区域", [this] { return std::make_unique<xActionDrawRegCircle>(m_view); } });
 }
 void MainWindow::onDrawRegArc()
 {
-    startAction([=] { return new xActionDrawRegArc(m_view); }, false);
+    startAction({ "圆弧区域", [this] { return std::make_unique<xActionDrawRegArc>(m_view); } });
 }
 void MainWindow::onDrawRegRect()
 {
-    startAction([=] { return new xActionDrawRegRect(m_view); }, false);
+    startAction({ "矩形区域", [this] { return std::make_unique<xActionDrawRegRect>(m_view); } });
 }
 void MainWindow::onDrawInterCircle()
 {
-    startAction([=] { return new xActionDrawInterCircle(m_view); }, true);
+    startAction({ "拟合圆", [this] { return std::make_unique<xActionDrawInterCircle>(m_view); }, true });
 }
 void MainWindow::onDrawInterArc()
 {
-    startAction([=] { return new xActionDrawInterArc(m_view); }, true);
+    startAction({ "拟合圆弧", [this] { return std::make_unique<xActionDrawInterArc>(m_view); }, true });
 }
 
 void MainWindow::paintEvent(QPaintEvent *e)
@@ -172,6 +201,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *e)
 void MainWindow::onOperateFinished()
 {
     m_view->finishAction();
+    destroyOperationWidget();
     ui.r_pop_widget->hide();
     ui.r_main_widget->show();
 }
@@ -179,6 +209,7 @@ void MainWindow::onOperateFinished()
 void MainWindow::onOperateCanceled()
 {
     m_view->cancelAction();
+    destroyOperationWidget();
     ui.r_pop_widget->hide();
     ui.r_main_widget->show();
 }

--- a/Graphics_demo/src/ui/MainWindow.h
+++ b/Graphics_demo/src/ui/MainWindow.h
@@ -2,6 +2,7 @@
 
 #include <QMainWindow>
 #include <functional>
+#include <memory>
 #include "ui_MainWindow.h"
 
 class xGraphicView;
@@ -39,11 +40,22 @@ private slots:
 	void onOperateCanceled();
 
 private:
-	void startAction(const std::function<xActionPreviewInterface *()> &factory, bool enableCalc);
+	using ActionFactory = std::function<std::unique_ptr<xActionPreviewInterface>()>;
+	struct ActionDescriptor
+	{
+		const char *name = "";
+		ActionFactory factory;
+		bool enableCalc = false;
+		bool enableNext = true;
+	};
+
+	void startAction(ActionDescriptor descriptor);
+	void destroyOperationWidget();
 
 	Ui::MainWindow ui;
 	xGraphicView *m_view = nullptr;
 	QGraphicsScene *m_scene = nullptr;
 	QVBoxLayout *m_vLayout = nullptr;
+	OperationWidget *m_operationWidget = nullptr;
 	bool m_firstResize = true;
 };

--- a/Graphics_demo/src/ui/OperationWidget.cpp
+++ b/Graphics_demo/src/ui/OperationWidget.cpp
@@ -8,16 +8,27 @@ OperationWidget::OperationWidget(QWidget *parent)
 	ui.setupUi(this);
 	setAttribute(Qt::WA_DeleteOnClose);
 	
-	connect(ui.confirmBtn, &QPushButton::clicked, this, [=] {
-		emit confirmEmit();
-		close();
-		});
-	connect(ui.cancelBtn, &QPushButton::clicked, this, [=] {
-		emit cancelEmit();
-		close();
-		});
+	connect(ui.confirmBtn, &QPushButton::clicked, this, &OperationWidget::confirmEmit);
+	connect(ui.cancelBtn, &QPushButton::clicked, this, &OperationWidget::cancelEmit);
 	connect(ui.calcBtn, &QPushButton::clicked, this, &OperationWidget::calcEmit);
 	connect(ui.nextBtn, &QPushButton::clicked, this, &OperationWidget::nextEmit);
+}
+
+void OperationWidget::setActionName(const QString &name)
+{
+	ui.label->setText(name);
+}
+
+void OperationWidget::setCalcEnabled(bool enabled)
+{
+	ui.calcBtn->setEnabled(enabled);
+	ui.calcBtn->setVisible(enabled);
+}
+
+void OperationWidget::setNextEnabled(bool enabled)
+{
+	ui.nextBtn->setEnabled(enabled);
+	ui.nextBtn->setVisible(enabled);
 }
 
 void OperationWidget::paintEvent(QPaintEvent *e)

--- a/Graphics_demo/src/ui/OperationWidget.h
+++ b/Graphics_demo/src/ui/OperationWidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QString>
 #include "ui_OperationWidget.h"
 
 class OperationWidget : public QWidget
@@ -9,6 +10,10 @@ class OperationWidget : public QWidget
 
 public:
 	OperationWidget(QWidget *parent = nullptr);
+
+	void setActionName(const QString &name);
+	void setCalcEnabled(bool enabled);
+	void setNextEnabled(bool enabled);
 
 signals:
 	void confirmEmit();


### PR DESCRIPTION
### Motivation
- 减少 `MainWindow` 中为每个绘图功能重复搭建 UI 与连接逻辑的编排，按 `ARCHITECTURE_REVIEW.md` 的 P0 建议收敛启动入口。
- 统一 Action 的生命周期与所有权，避免项目中混用裸指针与手动 `delete` 导致的不一致性和内存问题。
- 将操作面板的展示与行为配置下放到 `MainWindow`，降低 UI 自身对业务流程的耦合并统一销毁时机。

### Description
- 在 `MainWindow` 中引入 `ActionDescriptor`（包含 `name` / `factory` / `enableCalc` / `enableNext`）和 `ActionFactory` 类型，并将 `startAction` 改为接收该描述符以统一启动流程；增加 `destroyOperationWidget` 用于统一清理操作面板，且将各 `onDraw*` 改为通过描述符调用 `startAction`（使用 `std::make_unique` 创建具体 Action）。
- 将 `OperationWidget` 增加配置接口 `setActionName`、`setCalcEnabled`、`setNextEnabled`，并移除按钮内部的自关闭闭包，改由外层在确认/取消时统一销毁面板；信号连接改为直接发射信号（不再调用 `close()`）。
- 在 `xGraphicView` 中把当前 Action 与默认 Action 的拥有权从裸指针改为 `std::unique_ptr`，把 `setAction` 改为接收 `std::unique_ptr<xActionPreviewInterface>`，`getAction` 返回裸指针（`.get()`），并在 `finishAction` / `cancelAction` 中使用 `.reset()` 统一释放逻辑以消除手动 `delete` 分支。
- 增加了对 `QObject::destroyed` 连接的局部捕获安全处理，避免失效指针竞态。
- 主要变更文件：`Graphics_demo/src/ui/MainWindow.h/.cpp`、`Graphics_demo/src/ui/OperationWidget.h/.cpp`、`Graphics_demo/src/engine/xGraphicView.h/.cpp`。

### Testing
- 运行了 `git diff --check` 以检测差异中的格式/空白问题，检查通过且无错误输出。 
- 使用代码搜索验证了 `setAction` / `getAction` / 新配置接口的引用更新，搜索结果匹配预期替换。 
- 未在此变更上执行完整构建或单元测试，建议合并前执行一次完整构建和现有单元/集成测试以确认运行时行为。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9c35df64832986cfb5e840548cab)